### PR TITLE
Making script fail when any command fail

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 xcodebuild -scheme Clipinio -target Clipinio \
     -configuration Release \


### PR DESCRIPTION
This way if you don't have xcode installed and xcodebuild fails the copy doesn't get executed.

@benjohnde 